### PR TITLE
Use SVG badges in the README instead of the PNG ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ Amazon Web Services Pricing Ruby Gem
 ====================================
 
 [![](https://api.tddium.com:443/cloudhealthtech/amazon-pricing/badges/48071.png?badge_token=26071a8988b20f68cb9723defd7012fc33a180bc)](https://api.tddium.com:443/cloudhealthtech/amazon-pricing/suites/48071)
-[![Gem Version](https://badge.fury.io/rb/amazon-pricing.png)](http://badge.fury.io/rb/amazon-pricing)
-[![Code Climate](https://codeclimate.com/github/CloudHealth/amazon-pricing.png)](https://codeclimate.com/github/CloudHealth/amazon-pricing)
-[![Coverage Status](https://coveralls.io/repos/CloudHealth/amazon-pricing/badge.png?branch=master)](https://coveralls.io/r/CloudHealth/amazon-pricing?branch=master)
+[![Gem Version](https://badge.fury.io/rb/amazon-pricing.svg)](http://badge.fury.io/rb/amazon-pricing)
+[![Code Climate](https://codeclimate.com/github/CloudHealth/amazon-pricing/badges/gpa.svg)](https://codeclimate.com/github/CloudHealth/amazon-pricing)
+[![Coverage Status](https://coveralls.io/repos/CloudHealth/amazon-pricing/badge.svg?branch=master)](https://coveralls.io/r/CloudHealth/amazon-pricing?branch=master)
 
 About amazon-pricing
 --------------------


### PR DESCRIPTION
All except the Solano CI badge, partly because of #62, partly because it is not a "[shields.io](http://shields.io/)-style" badge.