### PR TITLE
Fix Coveralls badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Amazon Web Services Pricing Ruby Gem
 [![](https://api.tddium.com:443/cloudhealthtech/amazon-pricing/badges/48071.png?badge_token=26071a8988b20f68cb9723defd7012fc33a180bc)](https://api.tddium.com:443/cloudhealthtech/amazon-pricing/suites/48071)
 [![Gem Version](https://badge.fury.io/rb/amazon-pricing.svg)](http://badge.fury.io/rb/amazon-pricing)
 [![Code Climate](https://codeclimate.com/github/CloudHealth/amazon-pricing/badges/gpa.svg)](https://codeclimate.com/github/CloudHealth/amazon-pricing)
-[![Coverage Status](https://coveralls.io/repos/CloudHealth/amazon-pricing/badge.svg?branch=master)](https://coveralls.io/r/CloudHealth/amazon-pricing?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/CloudHealth/amazon-pricing/badge.svg?branch=master)](https://coveralls.io/github/CloudHealth/amazon-pricing?branch=master)
 
 About amazon-pricing
 --------------------


### PR DESCRIPTION
**Description:**

[When adding Bitbucket support](http://blog.coveralls.io/2015/07/07/Proud-to-Announce-Bitbucket-Support/), Coveralls broke all their badge URLs. [Not cool](http://www.w3.org/Provider/Style/URI.html).

PS: Can I haz push permissions pwease?

**Review:**

- [ ] Do the unit tests contain positive functionality tests as well as edge case negative tests?
- [ ] Can we monitor the performance/effectiveness of these changes?
- [ ] Did the code review consider failure modes and edge cases?
- [ ] Did the code review consider refactorings that would make this code more maintainable?
- [ ] Was this change approved by a module owner (if necessary)?