### PR TITLE
update to use most-recent aws URLs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    amazon-pricing (0.1.78)
+    amazon-pricing (0.1.79)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/amazon-pricing/definitions/rds-instance-type.rb
+++ b/lib/amazon-pricing/definitions/rds-instance-type.rb
@@ -119,6 +119,8 @@ module AwsPricing
           when 'upfront'
             db.set_prepay(type_of_instance, years, p.to_f) unless type_of_instance == :noupfront || p == "N/A"
           when 'monthlyStar'
+            # note for partialupfront, this purposely differs from AWS' "effective hourly" since we do not
+            # include the amortization of the partialupfront cost into this rate.
             db.set_price_per_hour(type_of_instance, years, p.to_f * 12 / 365 / 24) unless type_of_instance == :allupfront || p == "N/A"
           else
             # Do nothing for other names

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-  VERSION = '0.1.78'
+  VERSION = '0.1.79'
 end


### PR DESCRIPTION
There was missing AWS js URLs which were missing for RDS instances:  this now includes them.