### PR TITLE
Bump gem version and remove entries in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    amazon-pricing (0.1.78)
+    amazon-pricing (0.1.79)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-  VERSION = '0.1.78'
+  VERSION = '0.1.79'
 end


### PR DESCRIPTION
The Gemfile.lock changes were obtained by running `bundle install`.