### PR TITLE
Make sure capacity helpers do not raise an Error when there are no capacities for a given type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    amazon-pricing (0.1.79)
+    amazon-pricing (0.1.80)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/amazon-pricing/definitions/instance-type.rb
+++ b/lib/amazon-pricing/definitions/instance-type.rb
@@ -116,12 +116,18 @@ module AwsPricing
       end
     end
 
+    # Returns the bytes/s capacity if defined, `nil` otherwise
     def self.disk_bytes_per_sec_capacity(api_name)
-      PER_SEC_CAPACITIES[api_name][0] * 1024 * 1024
+      if PER_SEC_CAPACITIES[api_name]
+        PER_SEC_CAPACITIES[api_name][0] * 1024 * 1024
+      end
     end
 
+    # Returns the ops/s capacity if defined, `nil` otherwise
     def self.disk_ops_per_sec_capacity(api_name)
-      PER_SEC_CAPACITIES[api_name][1]
+      if PER_SEC_CAPACITIES[api_name]
+        PER_SEC_CAPACITIES[api_name][1]
+      end
     end
 
     protected

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-  VERSION = '0.1.79'
+  VERSION = '0.1.80'
 end


### PR DESCRIPTION
For example, calling `disk_bytes_per_sec_capacity('t1.micro')` would raise a `StandardError`.