### PR TITLE
Fix rollbar "No instance family members for rightsizing."

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    amazon-pricing (0.1.80)
+    amazon-pricing (0.1.81)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -14,7 +14,7 @@ module AwsPricing
         },
         'BurstableInstances' => {
             'CurrentGen' => {
-                'T2' => ['t2.micro', 't2.small', 't2.medium', 't2.large']
+                'T2' => ['t2.nano', 't2.micro', 't2.small', 't2.medium', 't2.large']
             }
         },
         'ComputeOptimized' => {
@@ -23,7 +23,7 @@ module AwsPricing
                 'C4' => ['c4.large', 'c4.xlarge', 'c4.2xlarge', 'c4.4xlarge', 'c4.8xlarge']
             },
             'PreviousGen' => {
-                'C1' => ['c1.medium', 'c1.xlarge'],
+                'C1' => ['c1.medium', 'c1.xlarge', 'cc1.4xlarge'],
                 'C2' => ['cc2.8xlarge']
             }
         },
@@ -139,6 +139,7 @@ module AwsPricing
       end
 
       def family_members(api_name)
+        puts "checking #{api_name}"
         all_instances.select { |family, instances| instances.include?(api_name) }.values.first
       end
 

--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -139,7 +139,6 @@ module AwsPricing
       end
 
       def family_members(api_name)
-        puts "checking #{api_name}"
         all_instances.select { |family, instances| instances.include?(api_name) }.values.first
       end
 

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-  VERSION = '0.1.80'
+  VERSION = '0.1.81'
 end

--- a/spec/lib/amazon-pricing/helpers/instance-type-spec.rb
+++ b/spec/lib/amazon-pricing/helpers/instance-type-spec.rb
@@ -11,15 +11,12 @@ describe 'AwsPricing::Helper::InstanceType' do
     # get a list of supported instance types, and filter out anything with more than 2 parts to its name (to get
     # rif of alias-y things like cache.m3.large and db.m3.large)
     types = AwsPricing::Ec2InstanceType.instance_eval("@Network_Performance").keys.reject {|k| k =~ /.*\..*\..*/}
-    puts types
 
     # test that we can get the family member for each type
     types.each do |type|
-      class_eval %*
-        it "should be able to get family members for #{type}" do
-          helper.family_members(type).should_not eq(nil)
-        end
-      *
+      it "should be able to get family members for #{type}" do
+        helper.family_members(type).should_not eq(nil)
+      end
     end
   end
 end

--- a/spec/lib/amazon-pricing/helpers/instance-type-spec.rb
+++ b/spec/lib/amazon-pricing/helpers/instance-type-spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'amazon-pricing/helpers/instance-type'
+require 'amazon-pricing/definitions/ec2-instance-type'
+
+describe 'AwsPricing::Helper::InstanceType' do
+  let(:dummy_class) { Class.new { include AwsPricing::Helper::InstanceType } }
+  let(:helper) {dummy_class.new }
+
+  context 'family_members' do
+
+    # get a list of supported instance types, and filter out anything with more than 2 parts to its name (to get
+    # rif of alias-y things like cache.m3.large and db.m3.large)
+    types = AwsPricing::Ec2InstanceType.instance_eval("@Network_Performance").keys.reject {|k| k =~ /.*\..*\..*/}
+    puts types
+
+    # test that we can get the family member for each type
+    types.each do |type|
+      class_eval %*
+        it "should be able to get family members for #{type}" do
+          helper.family_members(type).should_not eq(nil)
+        end
+      *
+    end
+  end
+end


### PR DESCRIPTION
Add missing instance types to classification data structure, and add a test to make sure all instance types we know about are represented