### PR TITLE
missing prices: oracle-se2 and byol; some aurora

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    amazon-pricing (0.1.84)
+    amazon-pricing (0.1.85)
 
 GEM
   remote: https://rubygems.org/
@@ -28,7 +28,6 @@ PLATFORMS
 
 DEPENDENCIES
   amazon-pricing!
-  pry
   rake
   rspec (~> 2.11.0)
   test-unit

--- a/lib/amazon-pricing/definitions/database-type.rb
+++ b/lib/amazon-pricing/definitions/database-type.rb
@@ -40,6 +40,8 @@ module AwsPricing
       'mariadb_standard'        => 'MariaDB',
       'mariadb_multiaz'         => 'MariaDB (Multi-AZ)',
 
+      'oracle_se2_standard'     => 'Oracle Database Standard Edition Two',
+      'oracle_se2_multiaz'      => 'Oracle Database Standard Edition Two (Multi-AZ)',
       # Oracle SE2 BYOL prices are copied from Enterprise BYOL prices and not collected
       # (so no need to add rds-price-list.rb)
       'oracle_se2_byol'         => 'Oracle Database Standard Edition Two (BYOL)',
@@ -55,14 +57,18 @@ module AwsPricing
       'postgres_multiaz'         => 'postgresql_multiaz',
       'postgresql'               => 'postgresql_standard',
       'postgresql_multiaz'       => 'postgresql_multiaz',
-      'oracle-se1(li)'           => 'oracle_se1_standard',
-      'oracle-se1(byol)'         => 'oracle_se1_byol',
-      'oracle-se1(li)_multiaz'   => 'oracle_se1_multiaz',
-      'oracle-se1(byol)_multiaz' => 'oracle_se1_byol_multiaz',
       'oracle-se(byol)'          => 'oracle_se_byol',
-      'oracle-ee(byol)'          => 'oracle_ee_byol',
       'oracle-se(byol)_multiaz'  => 'oracle_se_byol_multiaz',
+      'oracle-ee(byol)'          => 'oracle_ee_byol',
       'oracle-ee(byol)_multiaz'  => 'oracle_ee_byol_multiaz',
+      'oracle-se1(li)'           => 'oracle_se1_standard',
+      'oracle-se1(li)_multiaz'   => 'oracle_se1_multiaz',
+      'oracle-se1(byol)'         => 'oracle_se1_byol',
+      'oracle-se1(byol)_multiaz' => 'oracle_se1_byol_multiaz',
+      'oracle-se2(li)'           => 'oracle_se2_standard',
+      'oracle-se2(li)_multiaz'   => 'oracle_se2_multiaz',
+      'oracle-se2(byol)'         => 'oracle_se2_byol',
+      'oracle-se2(byol)_multiaz' => 'oracle_se2_byol_multiaz',
       'sqlserver-ee(byol)'       => 'sqlserver_ee_byol',
       'sqlserver-ee(byol)_multiaz' => 'sqlserver_ee_byol_multiaz',
       'sqlserver-ee(li)'         => 'sqlserver_ee_standard',
@@ -76,26 +82,19 @@ module AwsPricing
       'aurora'                   => 'aurora_standard',
       'mariadb'                  => 'mariadb_standard',
       'mariadb_multiaz'          => 'mariadb_multiaz',
-
-      # Oracle SE2 BYOL prices are copied from Enterprise BYOL prices and not collected
-      # (so no need to add rds-price-list.rb)
-      'oracle-se2(byol)'         => 'oracle_se2_byol',
-      'oracle-se2(byol)_multiaz' => 'oracle_se2_byol_multiaz',
     }
 
     @@DB_Deploy_Types = {
       :mysql        => [:standard, :multiaz],
       :postgresql   => [:standard, :multiaz],
       :oracle_se1   => [:standard, :multiaz, :byol, :byol_multiaz],
+      :oracle_se2   => [:standard, :multiaz, :byol, :byol_multiaz],
       :oracle_se    => [:byol, :byol_multiaz],
       :oracle_ee    => [:byol, :byol_multiaz],
       :sqlserver_se => [:standard, :multiaz, :byol, :byol_multiaz],
       :sqlserver_ee => [:byol, :byol_multiaz, :standard, :multiaz],
       :aurora       => [:standard],
       :mariadb      => [:standard, :multiaz],
-
-      # oracle_se2 prices are copied, not collected
-      :oracle_se2   => [:byol, :byol_multiaz],
     }
 
   	def self.display_name(name)
@@ -105,7 +104,7 @@ module AwsPricing
   	def self.get_database_name
       [:mysql, :postgresql, :oracle_se1, :oracle_se, :oracle_ee, :sqlserver_ex, :sqlserver_web,
         :sqlserver_se, :sqlserver_ee, :aurora, :mariadb,
-        :oracle_se2 # oracle_se2 prices are copied, not collected
+        :oracle_se2 # oracle_se2 now collected (but not byol)
       ]
   	end
 

--- a/lib/amazon-pricing/definitions/database-type.rb
+++ b/lib/amazon-pricing/definitions/database-type.rb
@@ -104,7 +104,7 @@ module AwsPricing
   	def self.get_database_name
       [:mysql, :postgresql, :oracle_se1, :oracle_se, :oracle_ee, :sqlserver_ex, :sqlserver_web,
         :sqlserver_se, :sqlserver_ee, :aurora, :mariadb,
-        :oracle_se2 # oracle_se2 now collected (but not byol)
+        :oracle_se2 # oracle_se2 license included prices are collected, and BYOL prices are copied from oracle_se
       ]
   	end
 

--- a/lib/amazon-pricing/definitions/rds-instance-type.rb
+++ b/lib/amazon-pricing/definitions/rds-instance-type.rb
@@ -85,8 +85,10 @@ module AwsPricing
           end
         end
       end
-      # Copy prices from oracle_se to oracle_se2
+      # Copy byol prices from oracle_se to oracle_{ee,se1,se2}
       if database_type == :oracle_se && is_byol
+        update_pricing :oracle_ee,  type_of_instance, json, is_multi_az, is_byol
+        update_pricing :oracle_se1, type_of_instance, json, is_multi_az, is_byol
         update_pricing :oracle_se2, type_of_instance, json, is_multi_az, is_byol
       end
     end
@@ -126,8 +128,10 @@ module AwsPricing
             # Do nothing for other names
         end
       end
-      # Copy prices from oracle_se to oracle_se2
+      # Copy byol prices from oracle_se to oracle_{ee,se1,se2}
       if database_type == :oracle_se && is_byol
+        update_pricing_new :oracle_ee,  type_of_instance, prices, term, is_multi_az, is_byol
+        update_pricing_new :oracle_se1, type_of_instance, prices, term, is_multi_az, is_byol
         update_pricing_new :oracle_se2, type_of_instance, prices, term, is_multi_az, is_byol
       end
     end

--- a/lib/amazon-pricing/rds-price-list.rb
+++ b/lib/amazon-pricing/rds-price-list.rb
@@ -52,6 +52,8 @@ module AwsPricing
             # License Included Charges supported: Standard Edition One, Standard Edition Two
             # BYOL Charges supported: do not vary by edition for BYOL Amazon RDS pricing.
             :oracle_se =>["byol-standard", "byol-multiAZ"],
+            # oracle_ee is not here (nor collected), see RESERVED_DB_WITH_SAME_PRICING2 below
+            # :oracle_se =>["byol-standard", "byol-multiAZ"],  # again, note only byol (so not needed)
             :oracle_se1=>["license-included-standard", "license-included-multiAZ"],
             :oracle_se2=>["license-included-standard", "license-included-multiAZ"]
         },

--- a/lib/amazon-pricing/rds-price-list.rb
+++ b/lib/amazon-pricing/rds-price-list.rb
@@ -20,9 +20,12 @@ module AwsPricing
       :mysql => {:mysql=>["standard","multiAZ"]},
       :postgresql => {:postgresql=>["standard","multiAZ"]},
       :oracle => {
-        :oracle_se1=>["li-standard","li-multiAZ","byol-standard","byol-multiAZ"],
+        # AWS: Oracle - Enterprise Edition, Standard Edition Two, Standard Edition, Standard Edition One.
+        # License Included Charges supported: Standard Edition One, Standard Edition Two
+        # BYOL Charges supported: do not vary by edition for BYOL Amazon RDS pricing.
         :oracle_se=>["byol-standard","byol-multiAZ"],
-        :oracle_ee=>["byol-standard","byol-multiAZ"]
+        :oracle_se1=>["li-standard","li-multiAZ"],
+        :oracle_se2=>["li-standard","li-multiAZ"]
       },
       :sqlserver => {
         :sqlserver_ex=>["li-ex"],
@@ -44,20 +47,27 @@ module AwsPricing
     @@RESERVED_DB_DEPLOY_TYPE2 = {
         :mysql => {:mysql=>["standard","multiAZ"]},
         :postgresql => {:postgresql=>["standard","multiAZ"]},
-        :oracle => {:oracle_se1=>["license-included-standard", "license-included-multiAZ"],
-                    :oracle_se=>["byol-standard", "byol-multiAZ"]},
+        :oracle => {
+            # AWS: Oracle - Enterprise Edition, Standard Edition Two, Standard Edition, Standard Edition One.
+            # License Included Charges supported: Standard Edition One, Standard Edition Two
+            # BYOL Charges supported: do not vary by edition for BYOL Amazon RDS pricing.
+            :oracle_se =>["byol-standard", "byol-multiAZ"],
+            :oracle_se1=>["license-included-standard", "license-included-multiAZ"],
+            :oracle_se2=>["license-included-standard", "license-included-multiAZ"]
+        },
         :sqlserver => {
             :sqlserver_ex =>["license-included-standard"],
-            :sqlserver_web=>["license-included-standard"],
+            :sqlserver_web=>["license-included-standard", "license-included-multiAZ"],
             :sqlserver_se =>["byol-standard", "byol-multiAZ", "license-included-standard", "license-included-multiAZ"],
             :sqlserver_ee =>["byol-standard", "byol-multiAZ", "license-included-standard", "license-included-multiAZ"]},
-        :aurora => {:aurora => ["multiAZ"]},
+        :aurora => {:aurora => ["standard", "multiAZ"]},
         :mariadb => {:mariadb => ["standard", "multiAZ"]}
     }
 
     @@RESERVED_DB_WITH_SAME_PRICING2 = {
         :mysql => [:mysql],
         :postgresql => [:postgresql],
+        :oracle_se2 => [:oracle_se2],
         :oracle_se1 => [:oracle_se1],
         :oracle_se => [:oracle_se, :oracle_ee],
         :sqlserver_ex => [:sqlserver_ex],

--- a/lib/amazon-pricing/rds-price-list.rb
+++ b/lib/amazon-pricing/rds-price-list.rb
@@ -23,9 +23,12 @@ module AwsPricing
         # AWS: Oracle - Enterprise Edition, Standard Edition Two, Standard Edition, Standard Edition One.
         # License Included Charges supported: Standard Edition One, Standard Edition Two
         # BYOL Charges supported: do not vary by edition for BYOL Amazon RDS pricing.
-        :oracle_se=>["byol-standard","byol-multiAZ"],
-        :oracle_se1=>["li-standard","li-multiAZ"],
-        :oracle_se2=>["li-standard","li-multiAZ"]
+        # NB: since we explicitly copy Oracle BYOL RdsInstanceType.update_pricing_new, repeated BYOL is redundant here;
+        #     only '#{db}' is used to build the URL, so repeated '#{db_type}' is like copying
+        :oracle_se =>["byol-standard", "byol-multiAZ"],
+        #:oracle_ee =>["byol-standard", "byol-multiAZ"],    # byol is same, so copied
+        :oracle_se1=>["li-standard", "li-multiAZ"],         # byol is same, so copied
+        :oracle_se2=>["se2-li-standard", "se2-li-multiAZ"]  # byol is same, so copied
       },
       :sqlserver => {
         :sqlserver_ex=>["li-ex"],
@@ -43,7 +46,8 @@ module AwsPricing
     }
 
     # the following cli will extract all the URLs referenced on the AWS pricing page that fetch_reserved_rds_instance_pricing2 uses:
-    # curl http://aws.amazon.com/rds/pricing/ 2>/dev/null | grep 'pricing' |grep reserved-instances
+    # curl https://aws.amazon.com/rds/pricing/ 2>/dev/null | grep 'model' |grep reserved-instances
+    # NB: the URL is built using '#{db_str}-#{deploy_type}', so repeats for 'db' below are required
     @@RESERVED_DB_DEPLOY_TYPE2 = {
         :mysql => {:mysql=>["standard","multiAZ"]},
         :postgresql => {:postgresql=>["standard","multiAZ"]},

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-  VERSION = '0.1.84'
+  VERSION = '0.1.85'
 end

--- a/test/ec2_instance_types_test.rb
+++ b/test/ec2_instance_types_test.rb
@@ -94,7 +94,7 @@ class TestEc2InstanceTypes < Test::Unit::TestCase
     assert region.ebs_price.standard_per_million_io == 0.05
     assert region.ebs_price.preferred_per_gb == 0.125
     assert region.ebs_price.preferred_per_iops == 0.065
-    assert region.ebs_price.s3_snaps_per_gb == 0.095
+    assert region.ebs_price.s3_snaps_per_gb == 0.05
     # next two prices were added by aws (May 09, 2016)
     assert region.ebs_price.ebs_optimized_hdd_per_gb == 0.045
     assert region.ebs_price.ebs_cold_hdd_per_gb == 0.025
@@ -189,7 +189,7 @@ class TestEc2InstanceTypes < Test::Unit::TestCase
 	assert region.ebs_price.standard_per_million_io == 0.065
     assert region.ebs_price.preferred_per_gb == 0.15
     assert region.ebs_price.preferred_per_iops == 0.078
-    assert region.ebs_price.s3_snaps_per_gb == 0.125
+    assert region.ebs_price.s3_snaps_per_gb == 0.066
     # next two prices were added by aws (May 09, 2016)
     assert region.ebs_price.ebs_optimized_hdd_per_gb == 0.054
     assert region.ebs_price.ebs_cold_hdd_per_gb == 0.03


### PR DESCRIPTION
**Description:**
Changes encompass the following:

- oracle-se2 (License Included) pricings were missing
- reordered enumeration of oracle instances, so permutations are more clear
- since oracle BYOL is the same for all types (as described by AWS), we now explicitly copy all byol
- minor change to sqlserver_web (includes multi-AZ), and, aurora (includes single-AZ).

Operationally, the result shows that oracle-se1 and oracle-se2 now yields the same number of prices;  and oracle-se/ee yields half that number (since they only have BYOL prices).

**Review:**

- [ ] Do the unit tests contain positive functionality tests as well as edge case negative tests?
- [ ] Can we monitor the performance/effectiveness of these changes?
- [ ] Did the code review consider failure modes and edge cases?
- [ ] Did the code review consider refactorings that would make this code more maintainable?
- [ ] Was this change approved by a module owner (if necessary)?