### PR TITLE
Fetch ECUs as floats instead of integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Change Log
+
+### Version 0.1.86
+
+  * Fix ECUs being fetched as integers instead of floats
+
 ### Version 0.1.25
 
   * Handle JSON::ParserError for RDS json doc (@lardcanoe)
@@ -8,7 +14,7 @@
 
 ### Version 0.1.7
 
-  * Refactored model to simplify access (one instance type for all usages), 
+  * Refactored model to simplify access (one instance type for all usages),
   introduced operating system pricing to suppport RHEL, SLES, etc...
 
 ### Version 0.0.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    amazon-pricing (0.1.85)
+    amazon-pricing (0.1.86)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/amazon-pricing/definitions/instance-type.rb
+++ b/lib/amazon-pricing/definitions/instance-type.rb
@@ -105,7 +105,7 @@ module AwsPricing
               begin
                 api_name = size["size"]
                 @@Memory_Lookup[api_name] = size["memoryGiB"].to_f * 1000
-                @@Compute_Units_Lookup[api_name] = size["ECU"].to_i
+                @@Compute_Units_Lookup[api_name] = size["ECU"].to_f
                 @@Virtual_Cores_Lookup[api_name] = size["vCPU"].to_i
               rescue UnknownTypeError
                 $stderr.puts "[populate_lookups] WARNING: encountered #{$!.message}"

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-  VERSION = '0.1.85'
+  VERSION = '0.1.86'
 end


### PR DESCRIPTION

Below is the result of:

```rb
> AwsPricing::InstanceType.populate_lookups
 => ["http://a0.awsstatic.com/pricing/1/ec2/linux-od.min.js", "http://a0.awsstatic.com/pricing/1/ec2/previous-generation/linux-od.min.js"]
> AwsPricing::InstanceType.class_variable_get(:@@Compute_Units_Lookup)
```

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<pre>{
        "t2.nano" => 0,
       "t2.micro" => 0,
       "t2.small" => 0,
      "t2.medium" => 0,
       "t2.large" => 0,
       "m4.large" => 6,
      "m4.xlarge" => 13,
     "m4.2xlarge" => 26,
     "m4.4xlarge" => 53,
    "m4.10xlarge" => 124,
      "m3.medium" => 3,
       "m3.large" => 6,
      "m3.xlarge" => 13,
     "m3.2xlarge" => 26,
       "c4.large" => 8,
      "c4.xlarge" => 16,
     "c4.2xlarge" => 31,
     "c4.4xlarge" => 62,
     "c4.8xlarge" => 132,
       "c3.large" => 7,
      "c3.xlarge" => 14,
     "c3.2xlarge" => 28,
     "c3.4xlarge" => 55,
     "c3.8xlarge" => 108,
     "g2.2xlarge" => 26,
     "g2.8xlarge" => 104,
    "x1.32xlarge" => 349,
       "r3.large" => 6,
      "r3.xlarge" => 13,
     "r3.2xlarge" => 26,
     "r3.4xlarge" => 52,
     "r3.8xlarge" => 104,
      "i2.xlarge" => 14,
     "i2.2xlarge" => 27,
     "i2.4xlarge" => 53,
     "i2.8xlarge" => 104,
      "d2.xlarge" => 14,
     "d2.2xlarge" => 28,
     "d2.4xlarge" => 56,
     "d2.8xlarge" => 116,
       "m1.small" => 1,
      "m1.medium" => 2,
       "m1.large" => 4,
      "m1.xlarge" => 8,
      "c1.medium" => 5,
      "c1.xlarge" => 20,
    "cc2.8xlarge" => 88,
    "cg1.4xlarge" => 33,
      "m2.xlarge" => 6,
     "m2.2xlarge" => 13,
     "m2.4xlarge" => 26,
    "cr1.8xlarge" => 88,
    "hi1.4xlarge" => 35,
    "hs1.8xlarge" => 35,
       "t1.micro" => 0
}</pre>
    </td>
    <td>
<pre>{
        "t2.nano" => 0.0,
       "t2.micro" => 0.0,
       "t2.small" => 0.0,
      "t2.medium" => 0.0,
       "t2.large" => 0.0,
       "m4.large" => 6.5,
      "m4.xlarge" => 13.0,
     "m4.2xlarge" => 26.0,
     "m4.4xlarge" => 53.5,
    "m4.10xlarge" => 124.5,
      "m3.medium" => 3.0,
       "m3.large" => 6.5,
      "m3.xlarge" => 13.0,
     "m3.2xlarge" => 26.0,
       "c4.large" => 8.0,
      "c4.xlarge" => 16.0,
     "c4.2xlarge" => 31.0,
     "c4.4xlarge" => 62.0,
     "c4.8xlarge" => 132.0,
       "c3.large" => 7.0,
      "c3.xlarge" => 14.0,
     "c3.2xlarge" => 28.0,
     "c3.4xlarge" => 55.0,
     "c3.8xlarge" => 108.0,
     "g2.2xlarge" => 26.0,
     "g2.8xlarge" => 104.0,
    "x1.32xlarge" => 349.0,
       "r3.large" => 6.5,
      "r3.xlarge" => 13.0,
     "r3.2xlarge" => 26.0,
     "r3.4xlarge" => 52.0,
     "r3.8xlarge" => 104.0,
      "i2.xlarge" => 14.0,
     "i2.2xlarge" => 27.0,
     "i2.4xlarge" => 53.0,
     "i2.8xlarge" => 104.0,
      "d2.xlarge" => 14.0,
     "d2.2xlarge" => 28.0,
     "d2.4xlarge" => 56.0,
     "d2.8xlarge" => 116.0,
       "m1.small" => 1.0,
      "m1.medium" => 2.0,
       "m1.large" => 4.0,
      "m1.xlarge" => 8.0,
      "c1.medium" => 5.0,
      "c1.xlarge" => 20.0,
    "cc2.8xlarge" => 88.0,
    "cg1.4xlarge" => 33.5,
      "m2.xlarge" => 6.5,
     "m2.2xlarge" => 13.0,
     "m2.4xlarge" => 26.0,
    "cr1.8xlarge" => 88.0,
    "hi1.4xlarge" => 35.0,
    "hs1.8xlarge" => 35.0,
       "t1.micro" => 0.0
}</pre>
    </td>
  </tr>
</table>