### PR TITLE
[ENG-4072]  fixes typo of i4 instance type that caused a rollbar

### DIFF
--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -42,7 +42,7 @@ module AwsPricing
             'CurrentGen' => {
                 'HS1' => ['hs1.8xlarge'],
                 'I2'  => ['i2.xlarge', 'i2.2xlarge', 'i2.4xlarge', 'i2.8xlarge'],
-                'I3'  => ['i3.large', 'i3.xlarge', 'i3.2xlarge', 'i3.4xlarge', 'i4.8xlarge', 'i3.16xlarge'],
+                'I3'  => ['i3.large', 'i3.xlarge', 'i3.2xlarge', 'i3.4xlarge', 'i3.8xlarge', 'i3.16xlarge'],
                 'D2'  => ['d2.xlarge', 'd2.2xlarge', 'd2.4xlarge', 'd2.8xlarge']
             },
             'PreviousGen' => {

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-VERSION = '0.1.95'
+VERSION = '0.1.96'
 end


### PR DESCRIPTION
fixing typo

Rollbar: #45172 CloudHealth::RightsizingJobError: Computing aws:ec2:instance scores for asset_id 2542620950959 failed: undefined method `index' for nil:NilClass