### PR TITLE
[ENG-9515] add cache.r4 support

### DIFF
--- a/lib/amazon-pricing/definitions/ec2-instance-type.rb
+++ b/lib/amazon-pricing/definitions/ec2-instance-type.rb
@@ -218,6 +218,12 @@ module AwsPricing
       'cache.r3.8xlarge' => :ten_gigabit,
       'cache.r3.large' => :moderate,
       'cache.r3.xlarge' => :moderate,
+      'cache.r4.16xlarge' => :twentyfive_gigabit,
+      'cache.r4.2xlarge' => :ten_gigabit, # upto 10G
+      'cache.r4.4xlarge' => :ten_gigabit, # upto 10G
+      'cache.r4.8xlarge' => :ten_gigabit,
+      'cache.r4.large' => :ten_gigabit,   # upto 10G
+      'cache.r4.xlarge' => :ten_gigabit,  # upto 10G
       'cache.x1.16xlarge' => :ten_gigabit,
       'cache.x1.32xlarge' => :ten_gigabit,
       'cache.t1.micro' => :very_low,

--- a/lib/amazon-pricing/definitions/instance-type.rb
+++ b/lib/amazon-pricing/definitions/instance-type.rb
@@ -330,7 +330,7 @@ module AwsPricing
       'cache.m2.xlarge' => 16700, 'cache.m2.2xlarge' => 33800, 'cache.m2.4xlarge' => 68000,
       'cache.c1.xlarge' => 6600,
       'cache.t1.micro' => 213,
-      'cache.r4.large' => 12300, 'cache.r4.xlarge' => 25050, 'cache.r4.2xlarge' => 50470, 'cache.r4.4xlarge' => 10138,
+      'cache.r4.large' => 12300, 'cache.r4.xlarge' => 25050, 'cache.r4.2xlarge' => 50470, 'cache.r4.4xlarge' => 101380,
          'cache.r4.8xlarge' => 203260, 'cache.r4.16xlarge' => 407000,
     }
     @@Virtual_Cores_Lookup = {

--- a/lib/amazon-pricing/definitions/instance-type.rb
+++ b/lib/amazon-pricing/definitions/instance-type.rb
@@ -330,6 +330,8 @@ module AwsPricing
       'cache.m2.xlarge' => 16700, 'cache.m2.2xlarge' => 33800, 'cache.m2.4xlarge' => 68000,
       'cache.c1.xlarge' => 6600,
       'cache.t1.micro' => 213,
+      'cache.r4.large' => 12300, 'cache.r4.xlarge' => 25050, 'cache.r4.2xlarge' => 50470, 'cache.r4.4xlarge' => 10138,
+         'cache.r4.8xlarge' => 203260, 'cache.r4.16xlarge' => 407000,
     }
     @@Virtual_Cores_Lookup = {
       'r3.large' => 2, 'r3.xlarge' => 4, 'r3.2xlarge' => 8, 'r3.4xlarge' => 16, 'r3.8xlarge' => 32,

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-VERSION = '0.1.103' # [major,minor.fix]: adding x1e additional sizes 
+VERSION = '0.1.104' # [major,minor.fix]: adding cache.r4
 end


### PR DESCRIPTION
this blocks pricing-update since it (now) shows as an unsupported type:  this adds in enough so it's a supported type.