### PR TITLE
[AWS-2539] adding i3.metal, fixes for linuxsql DH and DI

### DIFF
--- a/lib/amazon-pricing/definitions/ec2-instance-type.rb
+++ b/lib/amazon-pricing/definitions/ec2-instance-type.rb
@@ -304,6 +304,7 @@ module AwsPricing
       'i3.4xlarge' => :ten_gigabit,
       'i3.8xlarge' => :ten_gigabit,
       'i3.large' => :ten_gigabit,
+      'i3.metal' => :twentyfive_gigabit,
       'i3.xlarge' => :ten_gigabit,
       'm1.large' => :moderate,
       'm1.medium' => :moderate,

--- a/lib/amazon-pricing/definitions/instance-type.rb
+++ b/lib/amazon-pricing/definitions/instance-type.rb
@@ -207,6 +207,7 @@ module AwsPricing
       'i3.xlarge' => 'Storage Optimized High I/O Extra Large', 'i3.2xlarge' => 'Storage Optimized High I/O Double Extra Large',
       'i3.4xlarge' => 'Storage Optimized High I/O Quadruple Extra Large', 'i3.8xlarge' => 'Storage Optimized High I/O Extra Large',
       'i3.16xlarge' => 'Storage Optimized High I/O Hextuple Extra Large',
+      'i3.metal' => 'Storage Optimized High I/O Metal',
       'd2.xlarge' => 'Dense Storage Extra Large', 'd2.2xlarge' => 'Dense Storage Double Extra Large', 'd2.4xlarge' => 'Dense Storage Quadruple Extra Large', 'd2.8xlarge' => 'Dense Storage Eight Extra Large',
       'h1.2xlarge' => 'Dense Storage H1 Double Extra Large', 'h1.4xlarge' => 'Dense Storage H1 Quadruple Extra Large', 'h1.8xlarge' => 'Dense Storage H1 Eight Extra Large', 'h1.16xlarge' => 'Dense Storage H1 Hextuple Extra Large',
       'r3.large' => 'Memory Optimized Large', 'r3.xlarge' => 'Memory Optimized Extra Large', 'r3.2xlarge' => 'Memory Optimized Double Extra Large', 'r3.4xlarge' => 'Memory Optimized Quadruple Extra Large', 'r3.8xlarge' => 'Memory Optimized Eight Extra Large',
@@ -250,7 +251,7 @@ module AwsPricing
       'db.t1.micro' => 160,
       'c3.large' => 32, 'c3.xlarge' => 80, 'c3.2xlarge' => 160, 'c3.4xlarge' => 320, 'c3.8xlarge' => 640,
       'i2.xlarge' => 800, 'i2.2xlarge' => 1600, 'i2.4xlarge' => 3200, 'i2.8xlarge' => 6400,
-      'i3.large' => 475, 'i3.xlarge' => 950, 'i3.2xlarge' => 1900, 'i3.4xlarge' => 3800, 'i3.8xlarge' => 7600, 'i3.16xlarge' => 15200,
+      'i3.large' => 475, 'i3.xlarge' => 950, 'i3.2xlarge' => 1900, 'i3.4xlarge' => 3800, 'i3.8xlarge' => 7600, 'i3.16xlarge' => 15200, 'i3.metal' => 15200,
       'd2.xlarge' => 6000, 'd2.2xlarge' => 12000, 'd2.4xlarge' => 24000, 'd2.8xlarge' => 48000,
       'h1.2xlarge' => 2000, 'h1.4xlarge' => 4000, 'h1.8xlarge' => 8000, 'h1.16xlarge' => 16000,
       'r3.large' => 32, 'r3.xlarge' => 80, 'r3.2xlarge' => 160, 'r3.4xlarge' => 320, 'r3.8xlarge' => 640,
@@ -285,7 +286,7 @@ module AwsPricing
       'db.t1.micro' => 64,
       'c3.large' => 64, 'c3.xlarge' => 64, 'c3.2xlarge' => 64, 'c3.4xlarge' => 64, 'c3.8xlarge' => 64,
       'i2.large' => 64, 'i2.xlarge' => 64, 'i2.2xlarge' => 64, 'i2.4xlarge' => 64, 'i2.8xlarge' => 64,
-      'i3.large' => 64, 'i3.xlarge' => 64, 'i3.2xlarge' => 64, 'i3.4xlarge' => 64, 'i3.8xlarge' => 64, 'i3.16xlarge' => 64,
+      'i3.large' => 64, 'i3.xlarge' => 64, 'i3.2xlarge' => 64, 'i3.4xlarge' => 64, 'i3.8xlarge' => 64, 'i3.16xlarge' => 64, 'i3.metal' => 64,
       'd2.xlarge' => 64, 'd2.2xlarge' => 64, 'd2.4xlarge' => 64, 'd2.8xlarge' => 64,
       'h1.2xlarge' => 64, 'h1.4xlarge' => 64, 'h1.8xlarge' => 64, 'h1.16xlarge' => 64,
       'r3.large' => 64, 'r3.xlarge' => 64, 'r3.2xlarge' => 64, 'r3.4xlarge' => 64, 'r3.8xlarge' => 64,
@@ -320,7 +321,7 @@ module AwsPricing
       'db.t1.micro' => :ebs,
       'c3.large' => :ssd, 'c3.xlarge' => :ssd, 'c3.2xlarge' => :ssd, 'c3.4xlarge' => :ssd, 'c3.8xlarge' => :ssd,
       'i2.large' => :ssd, 'i2.xlarge' => :ssd, 'i2.2xlarge' => :ssd, 'i2.4xlarge' => :ssd, 'i2.8xlarge' => :ssd,
-      'i3.large' => :ssd, 'i3.xlarge' => :ssd, 'i3.2xlarge' => :ssd, 'i3.4xlarge' => :ssd, 'i3.8xlarge' => :ssd, 'i3.16xlarge' => :ssd,
+      'i3.large' => :ssd, 'i3.xlarge' => :ssd, 'i3.2xlarge' => :ssd, 'i3.4xlarge' => :ssd, 'i3.8xlarge' => :ssd, 'i3.16xlarge' => :ssd, 'i3.metal' => :ssd,
       'd2.xlarge' => :ephemeral, 'd2.2xlarge' => :ephemeral, 'd2.4xlarge' => :ephemeral, 'd2.8xlarge' => :ephemeral,
       'h1.2xlarge' => :ephemeral, 'h1.4xlarge' => :ephemeral, 'h1.8xlarge' => :ephemeral, 'h1.16xlarge' => :ephemeral,
       'r3.large' => :ssd, 'r3.xlarge' => :ssd, 'r3.2xlarge' => :ssd, 'r3.4xlarge' => :ssd, 'r3.8xlarge' => :ssd,
@@ -471,6 +472,7 @@ module AwsPricing
       'i3.4xlarge'  => [ 437, 16000], # EBSOptimized
       'i3.8xlarge'  => [ 875, 32500], # EBSOptimized
       'i3.16xlarge' => [1750, 65000],	# EBSOptimized
+      'i3.metal'    => [1250, 64000], # EBSOptimized
       'm1.large'  => [ 62, 4000], # EBSOptimized
       'm1.xlarge' => [125, 8000], # EBSOptimized
       'm2.2xlarge' => [ 62, 4000], # EBSOptimized

--- a/lib/amazon-pricing/ec2-dhi-price-list.rb
+++ b/lib/amazon-pricing/ec2-dhi-price-list.rb
@@ -14,7 +14,10 @@ module AwsPricing
 
     protected
 
-    @@OS_TYPES = [ 'linux', 'rhel', 'sles', 'mswin', 'mswinSQL', 'mswinSQLWeb', 'mswinSQLEnterprise' ]
+    @@OS_TYPES = [ 'linux', 'rhel', 'sles', 'mswin', 
+                   'mswinSQL', 'mswinSQLWeb', 'mswinSQLEnterprise',
+                   'linuxSQL', 'linuxSQLWeb', 'linuxSQLEnterprise',
+                 ]
 
     @@CAPACITY_HASH = {
       'c3' => { "large"=>16, "xlarge"=>8, "2xlarge"=>4, "4xlarge"=>2, "8xlarge"=>1 },
@@ -33,7 +36,7 @@ module AwsPricing
       'm4' => { "large"=>22, "xlarge"=>11, "2xlarge"=>5, "4xlarge"=>4, "10xlarge"=>1, "16xlarge"=>1 },
       'm5' => { "large"=>48, "xlarge"=>24, "2xlarge"=>12, "4xlarge"=>6, "12xlarge"=>2, "24xlarge"=>1 },
       'i2' => { "xlarge"=>8, "2xlarge"=>4, "4xlarge"=>2, "8xlarge"=>1, "16xlarge"=>1 },
-      'i3' => { "large"=>32, "xlarge"=>16, "2xlarge"=>8, "4xlarge"=>4, "8xlarge"=>2, "16xlarge"=>1 },
+      'i3' => { "large"=>32, "xlarge"=>16, "2xlarge"=>8, "4xlarge"=>4, "8xlarge"=>2, "16xlarge"=>1, "metal"=>1 },
       'x1' => { "16xlarge"=>2, "32xlarge"=>1 },
       'x1e' =>{ "xlarge"=>32, "2xlarge"=>16, "4xlarge"=>8, "8xlarge"=>4, "16xlarge"=>2, "32xlarge"=>1 },
     }

--- a/lib/amazon-pricing/ec2-di-price-list.rb
+++ b/lib/amazon-pricing/ec2-di-price-list.rb
@@ -20,7 +20,10 @@ module AwsPricing
         ['mswin', 'windows'],
         ['mswinSQL', 'windows-with-sql-server-standard'],
         ['mswinSQLWeb', 'windows-with-sql-server-web'],
-        ['mswinSQLEnterprise', 'windows-with-sql-server-enterprise']
+        ['mswinSQLEnterprise', 'windows-with-sql-server-enterprise'],
+        ['linuxSQL', 'linux-with-sql-server-standard'],
+        ['linuxSQLWeb', 'linux-with-sql-server-web'],
+        ['linuxSQLEnterprise', 'linux-with-sql-server-enterprise']
     ]
 
     OS_INDEX = 0

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-VERSION = '0.1.111' # [major,minor.fix]: adding c5d
+VERSION = '0.1.112' # [major,minor.fix]: adding i3.metal, and linuxsql dedicated variants
 end


### PR DESCRIPTION
This adds the 'basic' i3.metal support.
Due to the (lack of) clarity around SF for this, and the pervasive uses of the SIZE_TO_NF_TABLE hash clients, this change is initially/temporarily hard-coding the `metal` size as a fixed NF of 128 (this would only work for the i3 family).  The proposed new NF API (using api_name_to_nf) is also included here to ease the transition to handle `metal`.

The i3.metal is inherently _both_ Dedicated, and, Dedicated-Host.  This led to discovering a bug where we were not incorporating the previously-new linuxsql OS types, so that change is incorporated into this fix (to also support the i3 dedicated cases).

