### PR TITLE
[AWS-2720] adds missing linuxSQL variants for previousGen

### DIFF
--- a/lib/amazon-pricing/ec2-price-list.rb
+++ b/lib/amazon-pricing/ec2-price-list.rb
@@ -13,16 +13,21 @@ module AwsPricing
 
     protected
 
+    # the following were verified that the URL actually works:
+    # - note that mswinSQLEnterprise is not like the others (and linuxSQL* didn't work in NEW_OS_TYPES)
+    # - for new OS supported (like linuxSQL*), pay attention to #get_ec2_legacy_reserved_instance_pricing
+    #   to verify that pricing is available for previousGen instance types.
     @@OS_TYPES = [:linux, :mswin, :rhel, :sles, :mswinSQL, :mswinSQLWeb]
-    @@NEW_OS_TYPES = [:mswinSQLEnterprise, :linuxSQL, :linuxSQLWeb, :linuxSQLEnterprise]
+    @@NEW_OS_TYPES = [:mswinSQLEnterprise]
+    @@LINUXSQL_OS_TYPES = [:linuxSQL, :linuxSQLWeb, :linuxSQLEnterprise]
     @@LEGACY_RES_TYPES = [:light, :medium, :heavy]
 
     def get_ec2_on_demand_instance_pricing
-      (@@OS_TYPES + @@NEW_OS_TYPES).each do |os|
+      (@@OS_TYPES + @@NEW_OS_TYPES + @@LINUXSQL_OS_TYPES).each do |os|
         fetch_ec2_instance_pricing(EC2_BASE_URL + "#{os}-od.min.js", :ondemand, os)
       end
       # Rinse & repeat for legacy instances
-      @@OS_TYPES.each do |os|
+      (@@OS_TYPES + @@LINUXSQL_OS_TYPES).each do |os|
         fetch_ec2_instance_pricing(EC2_BASE_URL + "previous-generation/#{os}-od.min.js", :ondemand, os)
       end
     end
@@ -54,7 +59,10 @@ module AwsPricing
       end
 
       # I give up on finding a pattern so just iterating over known URLs
-      page_targets = {"linux-unix" => :linux, "red-hat-enterprise-linux" => :rhel, "suse-linux" => :sles, "windows" => :mswin, "windows-with-sql-server-standard" => :mswinSQL, "windows-with-sql-server-web" => :mswinSQLWeb}
+      page_targets = {"linux-unix" => :linux, "red-hat-enterprise-linux" => :rhel, "suse-linux" => :sles, "windows" => :mswin, 
+        "windows-with-sql-server-standard" => :mswinSQL, "windows-with-sql-server-web" => :mswinSQLWeb, 
+        "linux-with-sql-server-standard" => :linuxSQL, "linux-with-sql-server-web" => :linuxSQLWeb, "linux-with-sql-server-enterprise" => :linuxSQLEnterprise,
+      }
       page_targets.each_pair do |target, operating_system|
         url = "#{EC2_BASE_URL}previous-generation/ri-v2/#{target}-shared.min.js"
         fetch_ec2_instance_pricing_ri_v2(url, operating_system)

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-VERSION = '0.1.113' # [major,minor.fix]: adding m5d
+VERSION = '0.1.114' # [major,minor.fix]: adding linuxSQL* previousGen
 end


### PR DESCRIPTION
Missed capture (static js) pricing files for previousGen instance types.
