### PR TITLE
[AWS-2540] missed version bump to 116, for neptune

### DIFF
--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-VERSION = '0.1.115' # [major,minor.fix]: missed M5D occurrence
+VERSION = '0.1.116' # [major,minor.fix]: adding neptune db-engine
 end


### PR DESCRIPTION
missed version file, so can't publish gem (for neptune add)