### PR TITLE
AWS-3584: adding in support to allow us to automatically populate instance profiles

### DIFF
--- a/lib/amazon-pricing/definitions/ec2-instance-type.rb
+++ b/lib/amazon-pricing/definitions/ec2-instance-type.rb
@@ -187,10 +187,6 @@ module AwsPricing
       [api_name, name]
     end
 
-
-
-
-
     # throughput values for performance ratings
     # Amazon informally tells customers that they translate as follows:
     #   Low = 100 Mbps

--- a/lib/amazon-pricing/definitions/ec2-instance-type.rb
+++ b/lib/amazon-pricing/definitions/ec2-instance-type.rb
@@ -164,7 +164,7 @@ module AwsPricing
         when '25 Gigabit'
           throughput = :twentyfive_gigabit
         else
-          binding.pry
+          $stderr.puts "[#{__method__}] WARNING: unknown network throughput string:#{network_string}"
       end
       network_mbps = @Network_Throughput_MBits_Per_Second[throughput]
       [throughput.to_s, network_mbps]

--- a/lib/amazon-pricing/definitions/ec2-instance-type.rb
+++ b/lib/amazon-pricing/definitions/ec2-instance-type.rb
@@ -143,6 +143,34 @@ module AwsPricing
       network_mbps
     end
 
+    # Take in string from amazon pricing api, return network properties
+    def self.get_network_information(network_string)
+      throughput = nil
+      case network_string
+        when 'Very Low'
+          throughput = :very_low
+        when 'Low'
+          throughput = :low
+        when 'Low to Moderate'
+          throughput = :low_to_moderate
+        when 'Moderate'
+          throughput = :moderate
+        when 'High'
+          throughput = :high
+        when '10 Gigabit','Up to 10 Gigabit'
+          throughput = :ten_gigabit
+        when '20 Gigabit'
+          throughput = :twenty_gigabit
+        when '25 Gigabit'
+          throughput = :twentyfive_gigabit
+
+        else
+          binding.pry
+      end
+      network_mbps = @Network_Throughput_MBits_Per_Second[throughput]
+      [throughput.to_s, network_mbps]
+    end
+
     protected
     # Returns [api_name, name]
     def self.get_name(instance_type, api_name, is_reserved = false)
@@ -158,6 +186,10 @@ module AwsPricing
 
       [api_name, name]
     end
+
+
+
+
 
     # throughput values for performance ratings
     # Amazon informally tells customers that they translate as follows:

--- a/lib/amazon-pricing/definitions/ec2-instance-type.rb
+++ b/lib/amazon-pricing/definitions/ec2-instance-type.rb
@@ -144,6 +144,8 @@ module AwsPricing
     end
 
     # Take in string from amazon pricing api, return network properties
+    # Input: String containing network capacity from amazon-pricing-api
+    # Output: network throughput as a string, int containing network mbps
     def self.get_network_information(network_string)
       throughput = nil
       case network_string

--- a/lib/amazon-pricing/definitions/ec2-instance-type.rb
+++ b/lib/amazon-pricing/definitions/ec2-instance-type.rb
@@ -163,7 +163,6 @@ module AwsPricing
           throughput = :twenty_gigabit
         when '25 Gigabit'
           throughput = :twentyfive_gigabit
-
         else
           binding.pry
       end

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -8,5 +8,5 @@
 # Home::      http://github.com/CloudHealth/amazon-pricing
 #++
 module AwsPricing
-VERSION = '0.1.120' # [major,minor.fix]: adding osaka region
+VERSION = '0.1.121' # [major,minor.fix]: adding support to allow instance profile population
 end


### PR DESCRIPTION
#### Reviewers! 
Here's [How to do a Code Review](https://cloudhealthtech.atlassian.net/wiki/spaces/EN/pages/17989636/Code+Review)

#### Deploy readiness:

- [ ]  2 Reviews: 1 peer/buddy and 1 SME from [here](https://cloudhealthtech.atlassian.net/wiki/spaces/EN/pages/17989636/Code+Review)
- [ ]  Did you add the JIRA ticket ID to the PR title? 
- [ ]  Is your PR title **meaningful?** `[ENG-3333] Update pull request template`, not `Typo Fix` or `Add test`
- [ ]  After commits are squashed, will your primary commit message be meaningful?

#### Documentation links:

- JIRA Ticket(s):https://cloudhealthtech.atlassian.net/browse/AWS-3284
- Design Doc (where applicable):
- Link to passing Solano build (if PR tests are failing due to inter-repo dependencies):
  - [ ]  Branch pointers in Gemfile removed?

#### Proposed changes:
- Create new process, run by rake task, to automatically populate aws_instance_type_profiles if a new instance type is added
-*NOTE* This PR right now does *NOT* include code to allow updates of existing instance profiles if what we have in the table does not match the api. This will be a feature that will be added.


_Rollback Plan:_

-Revert

