### PR TITLE
Moving VPC only instance family array to be in amazon-pricing

### DIFF
--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -231,7 +231,7 @@ module AwsPricing
       end
 
 
-     # Remove metal from this array? force adoption of this
+      # Remove metal from this array? force adoption of this
       # NB: 'metal' is not in this table (since it's family specific), see #api_name_to_nf
       SIZE_TO_NF_TABLE = {
           "nano"    => 0.25,

--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -2,6 +2,9 @@ module AwsPricing
   module Helper
     module InstanceType
 
+
+      VPC_ONLY_INSTANCE_FAMILIES = ['a1', 'c4', 'c5', 'c5d', 'c5n', 'f1', 'g3', 'g3s', 'h1', 'i3', 'i3p', 'm4', 'm5', 'm5d', 'm5a', 'p2', 'p3', 'p3dn', 'r4', 't2', 't3', 'x1', 'x1e', 'r5', 'r5d', 'r5a', 'z1d', 'u-6tb1', 'u-9tb1', 'u-12tb1']
+
       METAL = 'metal'.freeze
       # the following family sizes should be kept in size order, see #api_name_to_nf below
       @@INSTANCE_TYPES_BY_CLASSIFICATION = {
@@ -227,7 +230,8 @@ module AwsPricing
         METAL_TO_NF_TABLE
       end
 
-      # Remove metal from this array? force adoption of this
+
+     # Remove metal from this array? force adoption of this
       # NB: 'metal' is not in this table (since it's family specific), see #api_name_to_nf
       SIZE_TO_NF_TABLE = {
           "nano"    => 0.25,

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -9,6 +9,5 @@
 #++
 module AwsPricing
 
-VERSION = '0.1.130' # [major,minor.fix]: Support for all metal instances
-
+VERSION = '0.1.131' # [major,minor.fix]: Moving VPC only instance families to be in amazon-pricing gem
 end


### PR DESCRIPTION
Jira Ticket: https://cloudhealthtech.atlassian.net/browse/ENG-15303
Moved previous declaration of VPC_ONLY_INSTANCE_FAMILIES out of other repository, where it was declared multiple times, to amazon-pricing. Should help speed up additions of new instance families, as we will have less code we have to update.