### PR TITLE
[QUAL-976] Fix the scheduled pipeline trigger in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,10 +7,10 @@ properties([
 ]);
 
 if (env.BRANCH_NAME == 'master') {
-   properties([pipelineTriggers([cron('H H(8-10) * * 4')])],
+   properties([pipelineTriggers([cron('H H(8-10) * * 4')]),
        [$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '15']],
        compressBuildLog()
-   );
+   ]);
 }
 
 // NODE FOR RUBY2.3.3-RAILS3.2


### PR DESCRIPTION
This PR fixes the syntax of the cron trigger scheduling so the master branch kicks off on a weekly interval.