### PR TITLE
Updating methods to allow us to access new api_name_to_nf method

### DIFF
--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -185,12 +185,14 @@ module AwsPricing
           sizes = family_members(name)
           # Return nil if we have a bogus instance type
           if sizes.nil?
-            raise UnknownTypeError, "Unknown instance type #{name}", caller
+            return nil
+            #raise UnknownTypeError, "Unknown instance type #{name}", caller
           end
           type = sizes[-1].split('.').last        # 'metal' defaults to largest size
           if sizes[-1].split('.').last == METAL
             if sizes.size == 1 # We have an instance family with only metals but no NF associated; raise an error
-              raise UnknownTypeError, "Unknown metal type #{name}", caller
+              return nil
+              #raise UnknownTypeError, "Unknown metal type #{name}", caller
             end
             type = sizes[-2].split('.').last      # 'metal' already largest, so 2nd largest
           end

--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -11,14 +11,14 @@ module AwsPricing
         'GeneralPurpose' => {
             'CurrentGen' => {
                 'A1' => ['a1.medium', 'a1.large', 'a1.xlarge', 'a1.2xlarge', 'a1.4xlarge'],
-                'M3' => ['m3.medium', 'm3.large', 'm3.xlarge', 'm3.2xlarge'],
                 'M4' => ['m4.large', 'm4.xlarge', 'm4.2xlarge', 'm4.4xlarge', 'm4.10xlarge', 'm4.16xlarge'],
                 'M5' => ['m5.large', 'm5.xlarge', 'm5.2xlarge', 'm5.4xlarge', 'm5.12xlarge', 'm5.24xlarge', 'm5.metal'],
                 'M5D' => ['m5d.large', 'm5d.xlarge', 'm5d.2xlarge', 'm5d.4xlarge', 'm5d.12xlarge', 'm5d.24xlarge', 'm5d.metal'],
                 'M5A' => ['m5a.large', 'm5a.xlarge', 'm5a.2xlarge', 'm5a.4xlarge', 'm5a.12xlarge', 'm5a.24xlarge'],
             },
             'PreviousGen' => {
-                'M1' => ['m1.small', 'm1.medium', 'm1.large', 'm1.xlarge']
+                'M1' => ['m1.small', 'm1.medium', 'm1.large', 'm1.xlarge'],
+                'M3' => ['m3.medium', 'm3.large', 'm3.xlarge', 'm3.2xlarge'],
             }
         },
         'BurstableInstances' => {
@@ -95,39 +95,39 @@ module AwsPricing
 
       # Important: Members of a family must be kept in 'size' order (small, medium, large, etc.)
       # AWS Docs: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html
-      def instance_types
+      def self.instance_types
         @@INSTANCE_TYPES_BY_CLASSIFICATION
       end
 
-      def general_purpose_instances
+      def self.general_purpose_instances
         instance_types['GeneralPurpose']
       end
 
-      def burstable_instances
+      def self.burstable_instances
         instance_types['BurstableInstances']
       end
 
-      def compute_optimized_instances
+      def self.compute_optimized_instances
         instance_types['ComputeOptimized']
       end
 
-      def memory_optimized_instances
+      def self.memory_optimized_instances
         instance_types['MemoryOptimized']
       end
 
-      def storage_optimized_instances
+      def self.storage_optimized_instances
         instance_types['StorageOptimized']
       end
 
-      def gpu_instances
+      def self.gpu_instances
         instance_types['GPUInstances']
       end
 
-      def micro_instances
+      def self.micro_instances
         instance_types['MicroInstances']
       end
 
-      def previous_generation_instances
+      def self.previous_generation_instances
         [
           general_purpose_instances['PreviousGen'],
           compute_optimized_instances['PreviousGen'],
@@ -142,7 +142,7 @@ module AwsPricing
         end
       end
 
-      def current_generation_instances
+      def self.current_generation_instances
         [
           general_purpose_instances['CurrentGen'],
           burstable_instances['CurrentGen'],
@@ -157,7 +157,7 @@ module AwsPricing
         end
       end
 
-      def all_instances
+      def self.all_instances
         @all_instances ||= begin
           [previous_generation_instances, current_generation_instances].inject({}) do |instances, family|
             instances.merge(family)
@@ -165,11 +165,11 @@ module AwsPricing
         end
       end
 
-      def family(api_name)
+      def self.family(api_name)
         all_instances.select { |family, instances| instances.include?(api_name) }.keys.first
       end
 
-      def family_members(api_name)
+      def self.family_members(api_name)
         all_instances.select { |family, instances| instances.include?(api_name) }.values.first
       end
 
@@ -185,7 +185,7 @@ module AwsPricing
           sizes = family_members(name)
           # Return nil if we have a bogus instance type
           if sizes.nil?
-            return nil
+            raise UnknownTypeError, "Unknown instance type #{name}", caller
           end
           type = sizes[-1].split('.').last        # 'metal' defaults to largest size
           if sizes[-1].split('.').last == METAL
@@ -224,10 +224,6 @@ module AwsPricing
 
       def self.metal_to_nf
         METAL_TO_NF_TABLE
-      end
-
-      def nf_to_size
-        NF_TO_SIZE_TABLE
       end
 
       # NB: 'metal' is not in this table (since it's family specific), see #api_name_to_nf

--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -173,7 +173,7 @@ module AwsPricing
         all_instances.select { |family, instances| instances.include?(api_name) }.values.first
       end
 
-      def api_name_to_nf(name)
+      def self.api_name_to_nf(name)
         type = name.split('.').last
         if (type == METAL)
           # See if our metal instance has a hard-coded nf value
@@ -218,20 +218,18 @@ module AwsPricing
         ["#{fam}.#{new_type}" , nf]
       end
 
-      def size_to_nf
+      def self.size_to_nf
         SIZE_TO_NF_TABLE
+      end
+
+      def self.metal_to_nf
+        METAL_TO_NF_TABLE
       end
 
       def nf_to_size
         NF_TO_SIZE_TABLE
       end
 
-      def metal_to_nf
-        METAL_TO_NF_TABLE
-      end
-
-
-      # Remove metal from this array? force adoption of this
       # NB: 'metal' is not in this table (since it's family specific), see #api_name_to_nf
       SIZE_TO_NF_TABLE = {
           "nano"    => 0.25,
@@ -249,7 +247,6 @@ module AwsPricing
           "10xlarge" => 80,
           "12xlarge" => 96,
           "16xlarge" => 128,
-          "metal" => 128,  # We will be removing this once size_to_nf is deprecated.
           "18xlarge" => 144,
           "24xlarge" => 192,
           "32xlarge" => 256,

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -9,5 +9,5 @@
 #++
 module AwsPricing
 
-VERSION = '0.1.133' # [major,minor.fix]: Adding m5/m5d/r5/rd5/z1d.metal support, clearing up throughput/IOPs map
+VERSION = '0.1.134' # [major,minor.fix]: Moving instance-type methods to be class methods rather than instance methods
 end


### PR DESCRIPTION
Updating all methods in instance-type to be class methods, rather than instance-methods, so api_name_to_nf can be used by other classes/modules outside of amazon-pricing.

Moving 'm3' into the previous generation instances, as it is no longer a current instance family