### PR TITLE
[ENG-16791] Substitute xl instance types for xlarge

### DIFF
--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -196,11 +196,7 @@ module AwsPricing
           end
         end
         full_type = type.gsub(/xl$/, 'xlarge')
-        nf = size_to_nf[full_type]
-        if nf.nil?
-          raise "No normalization factor found for api name: #{name}"
-        end
-        nf
+        size_to_nf[full_type]
       end
 
       # note: the next smaller type may _not_ be supported for a given family

--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -195,7 +195,8 @@ module AwsPricing
             type = sizes[-2].split('.').last      # 'metal' already largest, so 2nd largest
           end
         end
-        size_to_nf[type]
+        full_type = type.gsub(/xl$/, 'xlarge')
+        size_to_nf[full_type]
       end
 
       # note: the next smaller type may _not_ be supported for a given family

--- a/lib/amazon-pricing/helpers/instance-type.rb
+++ b/lib/amazon-pricing/helpers/instance-type.rb
@@ -196,7 +196,11 @@ module AwsPricing
           end
         end
         full_type = type.gsub(/xl$/, 'xlarge')
-        size_to_nf[full_type]
+        nf = size_to_nf[full_type]
+        if nf.nil?
+          raise "No normalization factor found for api name: #{name}"
+        end
+        nf
       end
 
       # note: the next smaller type may _not_ be supported for a given family

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -9,6 +9,6 @@
 #++
 module AwsPricing
 
-VERSION = '0.1.135' # [major,minor.fix]: Moving instance-type methods to be class methods rather than instance methods
+VERSION = '0.1.136' # [major,minor.fix]: Adding support for xl instance sizes to InstanceType module
 
 end

--- a/spec/lib/amazon-pricing/helpers/instance-type-spec.rb
+++ b/spec/lib/amazon-pricing/helpers/instance-type-spec.rb
@@ -27,8 +27,4 @@ describe 'AwsPricing::Helper::InstanceType' do
       expect(nf).to eq(AwsPricing::Helper::InstanceType.api_name_to_nf("#{size}xlarge"))
     end
   end
-
-  it 'should raise an exception if api_name_to_nf cannot find a nf' do
-    expect{AwsPricing::Helper::InstanceType.api_name_to_nf('bogus')}.to raise_error(RuntimeError)
-  end
 end

--- a/spec/lib/amazon-pricing/helpers/instance-type-spec.rb
+++ b/spec/lib/amazon-pricing/helpers/instance-type-spec.rb
@@ -3,9 +3,6 @@ require 'amazon-pricing/helpers/instance-type'
 require 'amazon-pricing/definitions/ec2-instance-type'
 
 describe 'AwsPricing::Helper::InstanceType' do
-  let(:dummy_class) { Class.new { include AwsPricing::Helper::InstanceType } }
-  let(:helper) {dummy_class.new }
-
   context 'family_members' do
 
     # get a list of supported instance types, and filter out anything with more than 2 parts to its name (to get
@@ -15,8 +12,23 @@ describe 'AwsPricing::Helper::InstanceType' do
     # test that we can get the family member for each type
     types.each do |type|
       it "should be able to get family members for #{type}" do
-        helper.family_members(type).should_not eq(nil)
+        AwsPricing::Helper::InstanceType.family_members(type).should_not eq(nil)
       end
     end
+  end
+
+  it 'should lookup *xl instance as *xlarge' do
+    expect(AwsPricing::Helper::InstanceType.api_name_to_nf('xl')).to(
+        eq(AwsPricing::Helper::InstanceType.api_name_to_nf('xlarge')))
+    expect(AwsPricing::Helper::InstanceType.api_name_to_nf('xl')).to_not eq nil
+    [2, 3, 4, 6, 8, 9, 10, 12, 16, 18, 24, 32].each do |size|
+      nf = AwsPricing::Helper::InstanceType.api_name_to_nf("#{size}xl")
+      expect(nf).to_not eq nil
+      expect(nf).to eq(AwsPricing::Helper::InstanceType.api_name_to_nf("#{size}xlarge"))
+    end
+  end
+
+  it 'should raise an exception if api_name_to_nf cannot find a nf' do
+    expect{AwsPricing::Helper::InstanceType.api_name_to_nf('bogus')}.to raise_error(RuntimeError)
   end
 end


### PR DESCRIPTION
I have a PR to switch a few usages of `SIZE_TO_NF_TABLE` in cht_billing to use this method, but I need it to support looking up normalization factor for `xl` instance types first.

For example `4xl` -> `4xlarge`

This uses a regex sub out any instance types ending in `xl` to end in `xlarge`

cht_billing PR: https://github.com/CloudHealth/cht_billing/pull/1396