### PR TITLE
[AWS-4393] Adding network capacity mapping

### DIFF
--- a/lib/amazon-pricing/definitions/ec2-instance-type.rb
+++ b/lib/amazon-pricing/definitions/ec2-instance-type.rb
@@ -191,10 +191,7 @@ module AwsPricing
         '100 Gigabit' => :one_hundred_gigabit
     }
 
-    # Map for network capacity descriptions. Called from instance-type.rb to
-    # populate network capacity on the aws asset page. If network_capacity is
-    # "0" We will default to unknown. Occurs for Host instances.
-    @Network_Capacity_Descriptions = ActiveSupport::HashWithIndifferentAccess.new(
+    @Network_Capacity_Descriptions = {
         very_low: "Very Low",
         low: "Low",
         low_to_moderate: "Low to Moderate",
@@ -205,7 +202,6 @@ module AwsPricing
         twenty_gigabit: "20 Gigabit",
         fifty_gigabit: "50 Gigabit",
         one_hundered_gigabit: "100 Gigabit",
-    ).freeze
-
+    }
   end
 end

--- a/lib/amazon-pricing/definitions/ec2-instance-type.rb
+++ b/lib/amazon-pricing/definitions/ec2-instance-type.rb
@@ -146,6 +146,10 @@ module AwsPricing
       [api_name, name]
     end
 
+    def self.get_network_capacity_descriptions
+      return @Network_Capacity_Descriptions
+    end
+
     # throughput values for performance ratings
     # Amazon informally tells customers that they translate as follows:
     #   Low = 100 Mbps
@@ -169,7 +173,7 @@ module AwsPricing
     # Use in population of profiles, takes in string value that amazon uses to reflect network capacity
     # Returns symbol we use to map to numeric value
     @Network_String_To_Sym = {
-        'Very Low' =>  :very_low,
+        'Very Low' => :very_low,
         'Low' => :low,
         'Low to Moderate' => :low_to_moderate,
         'Moderate' => :moderate,
@@ -186,6 +190,18 @@ module AwsPricing
         '50 Gigabit' => :fifty_gigabit,
         '100 Gigabit' => :one_hundred_gigabit
     }
+
+    @Network_Capacity_Descriptions = ActiveSupport::HashWithIndifferentAccess.new(
+        very_low: "Very Low",
+        low: "Low",
+        low_to_moderate: "Low to Moderate",
+        moderate: "Moderate",
+        high: "High",
+        ten_gigabit: "10 Gigabit",
+        twentyfive_gigabit: "25 Gigabit",
+        twenty_gigabit: "20 Gigabit",
+        fifty_gigabit: "50 Gigabit"
+    ).freeze
 
   end
 end

--- a/lib/amazon-pricing/definitions/ec2-instance-type.rb
+++ b/lib/amazon-pricing/definitions/ec2-instance-type.rb
@@ -191,6 +191,9 @@ module AwsPricing
         '100 Gigabit' => :one_hundred_gigabit
     }
 
+    # Map for network capacity descriptions. Called from instance-type.rb to
+    # populate network capacity on the aws asset page. If network_capacity is
+    # "0" We will default to unknown. Occurs for Host instances.
     @Network_Capacity_Descriptions = ActiveSupport::HashWithIndifferentAccess.new(
         very_low: "Very Low",
         low: "Low",
@@ -200,7 +203,8 @@ module AwsPricing
         ten_gigabit: "10 Gigabit",
         twentyfive_gigabit: "25 Gigabit",
         twenty_gigabit: "20 Gigabit",
-        fifty_gigabit: "50 Gigabit"
+        fifty_gigabit: "50 Gigabit",
+        one_hundered_gigabit: "100 Gigabit",
     ).freeze
 
   end

--- a/lib/amazon-pricing/version.rb
+++ b/lib/amazon-pricing/version.rb
@@ -9,6 +9,6 @@
 #++
 module AwsPricing
 
-VERSION = '0.1.142' # [major,minor.fix]: adding new m5*, r5*, c5, i3en.metal sizes
+VERSION = '0.1.143' # [major,minor.fix]: adding network capacity description hash
 
 end


### PR DESCRIPTION
Adding a network capacity description mapping

Current state:
<img width="1230" alt="Screen Shot 2019-07-15 at 10 37 03 AM" src="https://user-images.githubusercontent.com/29902475/61224795-3baa7e80-a6ed-11e9-91fc-3ca19cc378a8.png">
<img width="1232" alt="Screen Shot 2019-07-15 at 10 37 20 AM" src="https://user-images.githubusercontent.com/29902475/61224797-3baa7e80-a6ed-11e9-8a52-2f3720d25dcf.png">
After change:
<img width="1230" alt="Screen Shot 2019-07-15 at 10 41 22 AM" src="https://user-images.githubusercontent.com/29902475/61224796-3baa7e80-a6ed-11e9-965b-67c84f999ae8.png">
<img width="1227" alt="Screen Shot 2019-07-15 at 10 41 14 AM" src="https://user-images.githubusercontent.com/29902475/61224798-3baa7e80-a6ed-11e9-8ae8-32e666143c36.png">